### PR TITLE
Propose to replace Write-Log with Write-Host

### DIFF
--- a/ExTRA.psm1
+++ b/ExTRA.psm1
@@ -654,11 +654,11 @@ function Wait-EnterOrControlC {
 
                 # Enter or Ctrl+C exits the wait loop
                 if ($keyInfo.Key -eq [ConsoleKey]::Enter) {
-                    Write-Log "Enter key is detected"
+                    Write-Host "Enter key is detected"
                     $detectedKey = 'Enter'
                 }
                 elseif (($keyInfo.Modifiers -band [ConsoleModifiers]'Control') -and ($keyInfo.Key -eq [ConsoleKey]::C)) {
-                    Write-Log "Ctrl+C is detected"
+                    Write-Host "Ctrl+C is detected"
                     $detectedKey = 'Ctrl+C'
                 }
 


### PR DESCRIPTION
Collect-ExTRA always throws `CommandNotFoundException` after hitting Enter key since `Wait-EnterOrControlC` function includes an undefined cmdlet 'Write-Log'.

![image](https://github.com/jpmessaging/ExTRA/assets/6519947/47be325a-d3cc-43f6-8b22-d3795d1b93e1)

